### PR TITLE
Added feature: toggle display binary by nibble

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,11 @@
 					"type": "boolean",
 					"default": true,
 					"description": "Little Endian (true) or Big Endian (false)?"
+				},
+				"hexinspector.separateByByteOrNibble": {
+					"type": "boolean",
+					"default": true,
+					"description": "Separate by full bytes (true) or 4-bit nibbles (false)?"
 				}
 			}
 		},

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -21,6 +21,7 @@ export function activate(context: vscode.ExtensionContext) {
             var word = document.getText(document.getWordRangeAtPosition(position));
 
             let littleEndian: boolean = vscode.workspace.getConfiguration('hexinspector').get('endianness');
+            let separateByByte: boolean = vscode.workspace.getConfiguration('hexinspector').get('separateByByteOrNibble');
 
             let regexes = [
                 '0x([0-9a-fA-F]+)(?:[uU])?(?:[lL])?(?:[lL])?',
@@ -32,7 +33,7 @@ export function activate(context: vscode.ExtensionContext) {
                 let asUnsigned = utils.addThousandsSeparator(converters.bytesToUnsignedDec(bytes));
                 let asSigned = utils.addThousandsSeparator(converters.bytesToSignedDec(bytes));
                 let asDecimal = asUnsigned + (asSigned != asUnsigned ? ' / ' + asSigned : '');
-                let asBinary = utils.addBytesSeparator(converters.bytesToBin(bytes));
+                let asBinary = (separateByByte ? utils.addBytesSeparator(converters.bytesToBin(bytes)) : utils.addNibblesSeparator(converters.bytesToBin(bytes)) );
                 let asFloat16 = converters.bytesToFloat16(bytes);
                 let asFloat32 = converters.bytesToFloat32(bytes);
                 let asFloat64 = converters.bytesToFloat64(bytes);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -16,3 +16,6 @@ export function addThousandsSeparator(str: string) {
 export function addBytesSeparator(str: string) {
    return addSeparatorToNumber(str, ' ', 8);
 }
+export function addNibblesSeparator(str: string) {
+   return addSeparatorToNumber(str, ' ', 4);
+}


### PR DESCRIPTION
I was super pumped to find your extension today while trying to work through hundreds of lines of manual register writes. Thanks!

In my case, it's easier to read the register values by 4-bit nibble rather than byte, so I added a settings toggle to switch between the two formats.